### PR TITLE
Prepend LetsencryptRack middleware instead appending

### DIFF
--- a/lib/letsencrypt_rack/railtie.rb
+++ b/lib/letsencrypt_rack/railtie.rb
@@ -1,7 +1,7 @@
 module LetsencryptRack
   class Railtie < Rails::Railtie
     initializer "letsencrypt_rack.insert_middleware" do |app|
-      app.config.middleware.use LetsencryptRack::Middleware
+      app.config.middleware.unshift LetsencryptRack::Middleware
     end
   end
 end


### PR DESCRIPTION
In a situation where the app has force_ssl config option enabled and there's anything wrong with the certificate, it allows letsencrypt to reach `/.well-known/acme-challenge` endpoint anyway.

Is there any middleware that should be before this gem's middleware?